### PR TITLE
Disable flex display on submit button.

### DIFF
--- a/src/views/index/partials/main.sass
+++ b/src/views/index/partials/main.sass
@@ -104,9 +104,9 @@ section.main
                 min-width: 64px
                 min-height: 56px
                 padding: 8px
-                display: flex
-                justify-content: center
-                align-items: center
+                // display: flex
+                // justify-content: center
+                // align-items: center
                 transition: all .3s ease-out
 
                 &:hover


### PR DESCRIPTION
Tada emoji should now be centered in Safari.